### PR TITLE
feat(intl): :wrench: update android jsEngine for Intl support

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,4 +1,7 @@
 {
   "name": "ExampleApp",
-  "displayName": "ExampleApp"
+  "displayName": "ExampleApp",
+  "android": {
+    "jsEngine": "hermes"
+  }
 }


### PR DESCRIPTION
- This PR adds a config to use the "Hermes" engine as the default one in Android. 
- Helps to solve the below error on Android

```
ReferenceError: Can't find variable: Intl
ERROR  Invariant Violation: Failed to call into JavaScript module method AppRegistry.runApplication(). Module has not been registered as callable. Registered callable JavaScript modules (n = 11): Systrace, JSTimers, HeapCapture, SamplingProfiler, RCTLog, RCTDeviceEventEmitter, RCTNativeAppEventEmitter, GlobalPerformanceLogger, JSDevSupportModule, HMRClient, RCTEventEmitter.
A frequent cause of the error is that the application entry file path is incorrect. This can also happen when the JS bundle is corrupt or there is an early initialization error when loading React Native.
```